### PR TITLE
Fix removedHeaders array entries

### DIFF
--- a/ytp.php
+++ b/ytp.php
@@ -125,11 +125,11 @@ function makeRequest($url) {
     "Content-Length",
     "Host",
     "Origin",
-	"Content-Security-Policy".
-	"X-Frame-Options",
-	"X-Content-Type-Options",
-	"Strict-Transport-Security",
-	"X-Xss-Protection"
+    "Content-Security-Policy",
+    "X-Frame-Options",
+    "X-Content-Type-Options",
+    "Strict-Transport-Security",
+    "X-Xss-Protection"
   ));
 
   $removedHeaders = array_map("strtolower", $removedHeaders);


### PR DESCRIPTION
## Summary
- ensure each security header is a discrete entry in the removedHeaders array of ytp.php

## Testing
- php -l ytp.php

------
https://chatgpt.com/codex/tasks/task_e_68df5f30c6508323ab7b8c4cf60ad7cd