### PR TITLE
Guard proxy protocol overrides when header missing

### DIFF
--- a/mini.php
+++ b/mini.php
@@ -37,12 +37,12 @@ $landingExampleURL = "https://old.reddit.com";
 /****************************** END CONFIGURATION ******************************/
 
 //Fix https and heroku
-if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
   $_SERVER['HTTPS']='on';
   $_SERVER["SERVER_PORT"]=443;
 }
 
-if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'http') {
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'http') {
   $_SERVER["SERVER_PORT"]=80;
 }
 


### PR DESCRIPTION
## Summary
- guard mini proxy protocol overrides so the script skips them when `HTTP_X_FORWARDED_PROTO` is absent

## Testing
- php -S 127.0.0.1:8000 mini.php (in another shell) + curl -I http://127.0.0.1:8000/

------
https://chatgpt.com/codex/tasks/task_e_68df5fb128248323be4a36fbf0822542