### PR TITLE
Fix selection2 scripts and add media hub

### DIFF
--- a/selection2.html
+++ b/selection2.html
@@ -5,7 +5,7 @@
     <link href="./css/bootstrap.min.css" rel="stylesheet">
     <link href="./css/primary.css" rel="stylesheet">
     <link href="./css/transitions.css" rel="stylesheet">
-    <script src=".js/main.js"></script>
+    <script src="js/main.js"></script>
     <script src="js/analytics.js"></script>
     <link href="./font/fontawesome/css/all.css" rel="stylesheet">
   </head>

--- a/selection2b.html
+++ b/selection2b.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>GoldenNetwork Media Hub</title>
+    <link href="css/primary.css" rel="stylesheet">
+    <link href="./css/bootstrap.min.css" rel="stylesheet">
+    <link href="./css/transitions.css" rel="stylesheet">
+  </head>
+  <body class="whitebg">
+    <div class="wrap animated fadeIn">
+      <div class="c-box">
+        <center>
+          <h1><span style="color: white;">Welcome to the Media Hub</span></h1>
+          <h4><span style="color: #2db194;">Stream movies, documentaries, and TV shows without leaving GoldenNetwork.</span></h4>
+          <p><span style="color: white;">Select one of the portals below to jump into a catalogue of on-demand content. These resources mirror the layout used on our games page so the experience feels familiar.</span></p>
+        </center>
+      </div>
+
+      <div class="d-box">
+        <center>
+          <h2>Featured Streaming Portals</h2>
+        </center>
+        <div style="height: 15px;"></div>
+        <a href="selection4.html"><span style="color: white;">GoldenNetwork Curated Library</span></a>
+        <div style="height: 10px;"></div>
+        <a href="youtube.html"><span style="color: white;">YouTube (Invidious Proxy)</span></a>
+        <div style="height: 10px;"></div>
+        <a href="externalserver1.html"><span style="color: white;">Muun External Proxy (Use for blocked sites)</span></a>
+        <div style="height: 10px;"></div>
+        <a href="externalserver2.html"><span style="color: white;">Project Antares Media Proxy</span></a>
+      </div>
+
+      <div class="d-box">
+        <center>
+          <h2>Helpful Tools</h2>
+        </center>
+        <div style="height: 15px;"></div>
+        <a href="bookmarklets.html"><span style="color: white;">Bookmarklets &amp; Utilities</span></a>
+        <div style="height: 10px;"></div>
+        <a href="contact.html"><span style="color: white;">Need help? Contact the team</span></a>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- point the selection2 page at the actual js/main.js bundle so the UI scripts load correctly
- add the new selection2b.html media hub frame content that mirrors the arcade layout and links to existing streaming resources

## Testing
- python3 -m http.server 8000 & curl -I http://127.0.0.1:8000/selection2.html
- curl -I http://127.0.0.1:8000/selection2b.html
- curl -I http://127.0.0.1:8000/js/main.js

------
https://chatgpt.com/codex/tasks/task_e_68df61a7122c83239a71ceb053a36c35