### PR TITLE
Refactor selection pages with Vue components

### DIFF
--- a/js/gameApp.js
+++ b/js/gameApp.js
@@ -1,0 +1,230 @@
+import { computed, createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js';
+
+const gameLibrary = [
+  {
+    id: 'html5',
+    title: 'HTML5 Games',
+    description: 'Modern, plugin-free experiences that run smoothly on any device.',
+    games: [
+      { name: '2048', url: 'gfiles/html5games/2048/index.html', tags: ['puzzle'] },
+      { name: 'Astray', url: 'gfiles/html5games/astray/index.html', tags: ['maze', '3d'] },
+      { name: 'Breaklock', url: 'gfiles/html5games/breaklock/index.html', tags: ['logic'] },
+      { name: 'Breakout', url: 'gfiles/html5games/nerd.html', tags: ['arcade', 'classic'] },
+      { name: 'Cookie Clicker', url: 'gfiles/cookies/index.html', tags: ['idle'] },
+      { name: 'Flappy Bird', url: 'gfiles/html5games/flappybird/index.html', tags: ['arcade'] },
+      { name: 'Hextris', url: 'gfiles/html5games/hextris/index.html', tags: ['puzzle'] },
+      { name: 'Onslaught! Arena', url: 'gfiles/onslaughtarena.html', tags: ['action'] },
+      { name: 'Pac-Man', url: 'gfiles/html5games/pacman/index.htm', tags: ['arcade', 'classic'] },
+      { name: 'Radius Raid', url: 'gfiles/html5games/radius-raid/min.html', tags: ['shooter'] },
+      { name: 'Space Invaders', url: 'gfiles/html5games/spaceinvaders/index.html', tags: ['arcade', 'classic'] },
+      { name: 'Towermaster', url: 'gfiles/html5games/towermaster/index.html', tags: ['strategy'] }
+    ]
+  },
+  {
+    id: 'flash',
+    title: 'Flash Games',
+    description: 'Curated classics preserved with Flash emulation for the full nostalgia trip.',
+    games: [
+      { name: '1 on 1 Soccer', url: 'gfiles/1-on-1-soccer.html', tags: ['sports'] },
+      { name: 'Achievement Unlocked', url: 'gfiles/achievement-unlocked.html', tags: ['platformer'] },
+      { name: 'Achievement Unlocked 2', url: 'gfiles/achievementunlocked2.html', tags: ['platformer'] },
+      { name: 'Achievement Unlocked 3', url: 'gfiles/achievementunlocked3.html', tags: ['platformer'] },
+      { name: 'Action Turnip', url: 'gfiles/action-turnip.html', tags: ['action'] },
+      { name: 'Adaran', url: 'gfiles/adaran.html', tags: ['action'] },
+      { name: 'Adrenaline', url: 'gfiles/adrenaline.html', tags: ['action'] },
+      { name: 'Agar.io', url: 'gfiles/agario.html', tags: ['multiplayer'] },
+      { name: 'Arkandian Revenant', url: 'gfiles/arkandianrenevant.html', tags: ['rpg'] },
+      { name: 'Awesome Cars', url: 'gfiles/awesome-cars.html', tags: ['racing'] },
+      { name: 'Awesome Planes', url: 'gfiles/awesome-planes.html', tags: ['shooter'] },
+      { name: 'Bloons Player Pack 2', url: 'gfiles/balloons-player-pack-2.html', tags: ['tower defense'] },
+      { name: 'Bloons TD 3', url: 'gfiles/bloonstd3.html', tags: ['tower defense'] },
+      { name: 'Bloons TD 4', url: 'gfiles/bloonstd4.html', tags: ['tower defense'] },
+      { name: 'Bloons TD 5', url: 'gfiles/balloons-td-5.html', tags: ['tower defense'] },
+      { name: 'BoomBot 2', url: 'gfiles/boombot2.html', tags: ['puzzle'] },
+      { name: 'Boxhead 2 Player', url: 'gfiles/boxhead2player.html', tags: ['action'] },
+      { name: 'Bullet Bill', url: 'gfiles/bulletbill.html', tags: ['arcade'] },
+      { name: 'Casualty Chrome', url: 'gfiles/casualty.html', tags: ['puzzle'] },
+      { name: 'Computer Smashing', url: 'gfiles/computerbreak.html', tags: ['arcade'] },
+      { name: 'Crush the Castle', url: 'gfiles/crushthecastle.html', tags: ['physics'] },
+      { name: 'Cubefield', url: 'gfiles/cubefield.html', tags: ['arcade'] },
+      { name: 'Cyclomaniacs', url: 'gfiles/cyclomaniacs.html', tags: ['racing'] },
+      { name: 'Donkey Kong', url: 'gfiles/donkeykong.html', tags: ['arcade', 'classic'] },
+      { name: "Don't Shoot The Puppy", url: 'gfiles/dontshootthepuppy.html', tags: ['strategy'] },
+      { name: 'Doodle Defender', url: 'gfiles/doodledefender.html', tags: ['shooter'] },
+      { name: 'Doom', url: 'gfiles/doom.html', tags: ['shooter', 'classic'] },
+      { name: 'Duck Life 4', url: 'gfiles/ducklife4.html', tags: ['simulation'] },
+      { name: 'Earn to Die: Super Wheel', url: 'gfiles/earntodiesw.html', tags: ['racing'] },
+      { name: 'Electric Man', url: 'gfiles/electricman.html', tags: ['fighting'] },
+      { name: 'Electric Man 2', url: 'gfiles/electricman2.html', tags: ['fighting'] },
+      { name: 'Elephant Quest', url: 'gfiles/elephantquest.html', tags: ['platformer'] },
+      { name: 'Epic Combo: Redux', url: 'gfiles/epiccomboredux.html', tags: ['arcade'] },
+      { name: 'Exit Path', url: 'gfiles/exitpath.html', tags: ['platformer'] },
+      { name: 'Fancy Pants World 3', url: 'gfiles/fancypantsworld3.html', tags: ['platformer'] },
+      { name: 'Flash Flight Simulator', url: 'gfiles/flashflightsimulator.html', tags: ['simulation'] },
+      { name: 'Flight', url: 'gfiles/flight.html', tags: ['arcade'] },
+      { name: 'Happy Wheels', url: 'gfiles/happywheels.html', tags: ['ragdoll'] },
+      { name: 'Hobo', url: 'gfiles/hobo.html', tags: ['fighting'] },
+      { name: 'Hobo: Prison Brawl', url: 'gfiles/hobo2.html', tags: ['fighting'] },
+      { name: 'Hobo 3', url: 'gfiles/hobo3.html', tags: ['fighting'] },
+      { name: 'Hobo 5', url: 'gfiles/hobo5.html', tags: ['fighting'] },
+      { name: 'Hobo 6', url: 'gfiles/hobo6.html', tags: ['fighting'] },
+      { name: 'Infector 2', url: 'gfiles/infector2.html', tags: ['strategy'] },
+      { name: 'Interactive Buddy', url: 'gfiles/interactivebuddy.html', tags: ['sandbox'] },
+      { name: 'Jumpix 2', url: 'gfiles/jumpix2.html', tags: ['platformer'] },
+      { name: 'Learn to Fly', url: 'gfiles/learntofly.html', tags: ['arcade'] },
+      { name: 'Learn to Fly 2', url: 'gfiles/learntofly2.html', tags: ['arcade'] },
+      { name: 'Magnet Face', url: 'gfiles/magnetface.html', tags: ['puzzle'] },
+      { name: 'Mario Racing Tournament', url: 'gfiles/marioracingtournament.html', tags: ['racing'] },
+      { name: 'Megaman Project X', url: 'gfiles/megamanprojectx.html', tags: ['action'] },
+      { name: 'Metroid 2', url: 'gfiles/metroid2.html', tags: ['action'] },
+      { name: 'Mineblocks', url: 'gfiles/mineblocks.html', tags: ['sandbox'] },
+      { name: 'Millionaire to Billionaire', url: 'gfiles/millionairetobillionaire.html', tags: ['strategy'] },
+      { name: "Mirror's Edge", url: 'gfiles/mirrorsedge.html', tags: ['platformer'] },
+      { name: 'Motherload', url: 'gfiles/motherload.html', tags: ['mining'] },
+      { name: 'Multitask', url: 'gfiles/multitask.html', tags: ['arcade'] },
+      { name: 'Mutilate A Doll 2', url: 'gfiles/mutilateadoll.html', tags: ['sandbox'] },
+      { name: 'My Angel', url: 'gfiles/myangel.html', tags: ['arcade'] },
+      { name: 'Nanotube', url: 'gfiles/nanotube.html', tags: ['arcade'] },
+      { name: 'N Game', url: 'gfiles/ngame.html', tags: ['platformer'] },
+      { name: 'N Game 2', url: 'gfiles/ngame2.html', tags: ['platformer'] },
+      { name: 'Nucleus', url: 'gfiles/nucleus.html', tags: ['puzzle'] },
+      { name: 'Nyan Cat: Lost in Space', url: 'gfiles/nyancat.html', tags: ['arcade'] },
+      { name: 'One Man Army 2', url: 'gfiles/onemanarmy2.html', tags: ['action'] },
+      { name: 'Pandemic', url: 'gfiles/pandemic.html', tags: ['strategy'] },
+      { name: 'Pandemic 2', url: 'gfiles/pandemic2.html', tags: ['strategy'] },
+      { name: 'Papas Freezeria', url: 'gfiles/papasfreezeria.html', tags: ['simulation'] },
+      { name: 'Pause Ahead', url: 'gfiles/pauseahead.html', tags: ['platformer'] },
+      { name: 'Portal', url: 'gfiles/portal.html', tags: ['puzzle'] },
+      { name: 'Portal 2D', url: 'gfiles/portal2d.html', tags: ['puzzle'] },
+      { name: 'Raft Wars', url: 'gfiles/raftwars.html', tags: ['strategy'] },
+      { name: 'Raze 2', url: 'gfiles/raze2.html', tags: ['shooter'] },
+      { name: 'Redshift', url: 'gfiles/redshift.html', tags: ['shooter'] },
+      { name: 'Run 3', url: 'gfiles/run3.html', tags: ['endless runner'] },
+      { name: 'Sports Heads Soccer', url: 'gfiles/sportsheadssoccer.html', tags: ['sports'] },
+      { name: 'Stick RPG', url: 'gfiles/stickrpg.html', tags: ['rpg'] },
+      { name: 'Stick Run 2', url: 'gfiles/stickrun2.html', tags: ['arcade'] },
+      { name: 'Stick War', url: 'gfiles/stickwar.html', tags: ['strategy'] },
+      { name: 'Stick War 2', url: 'gfiles/stickwar2.html', tags: ['strategy'] },
+      { name: 'Strike Force Heroes', url: 'gfiles/strikeforceheroes.html', tags: ['shooter'] },
+      { name: 'Strike Force Heroes 2', url: 'gfiles/strikeforceheroes2.html', tags: ['shooter'] },
+      { name: 'Strike Force Kitty: Last Stand', url: 'gfiles/strikeforcekittyls.html', tags: ['strategy'] },
+      { name: 'Super Mario 63', url: 'gfiles/supermario63.html', tags: ['platformer'] },
+      { name: 'Super Smash Flash 2', url: 'gfiles/smashflash2.html', tags: ['fighting'] },
+      { name: 'Tactical Assassin', url: 'gfiles/tacticalassassin.html', tags: ['shooter'] },
+      { name: 'Tank Trouble', url: 'gfiles/tanktrouble.html', tags: ['strategy'] },
+      { name: 'The Binding of Isaac', url: 'gfiles/thebindingofisaac.html', tags: ['roguelike'] }
+    ]
+  }
+];
+
+const normalise = (value) => value.toLowerCase();
+
+const mountGameApp = (mountSelector) => {
+  const mountPoint = document.querySelector(mountSelector);
+  if (!mountPoint) {
+    return;
+  }
+
+  const totalGames = gameLibrary.reduce((count, category) => count + category.games.length, 0);
+
+  createApp({
+    setup() {
+      const searchTerm = ref('');
+
+      const filteredCategories = computed(() => {
+        const query = normalise(searchTerm.value.trim());
+
+        return gameLibrary
+          .map((category) => {
+            const games = !query
+              ? category.games
+              : category.games.filter((game) => {
+                  const haystack = [game.name, ...(game.tags ?? [])]
+                    .filter(Boolean)
+                    .map((entry) => normalise(entry));
+
+                  return haystack.some((entry) => entry.includes(query));
+                });
+
+            return {
+              ...category,
+              games
+            };
+          })
+          .filter((category) => !query || category.games.length > 0);
+      });
+
+      const visibleCount = computed(() =>
+        filteredCategories.value.reduce((count, category) => count + category.games.length, 0)
+      );
+
+      const hasResults = computed(() => visibleCount.value > 0);
+
+      const clearSearch = () => {
+        searchTerm.value = '';
+      };
+
+      return {
+        clearSearch,
+        filteredCategories,
+        hasResults,
+        searchTerm,
+        totalGames,
+        visibleCount
+      };
+    },
+    template: /* html */ `
+      <div class="game-library d-flex flex-column gap-5">
+        <div class="content-card text-white">
+          <div class="row g-3 align-items-end">
+            <div class="col-12 col-md-8">
+              <label class="form-label text-white-50 fw-semibold" for="game-search">Search the library</label>
+              <input
+                id="game-search"
+                class="form-control form-control-lg"
+                type="search"
+                placeholder="Search by title or tag (e.g. tower defense, racing)"
+                v-model.trim="searchTerm"
+                autocomplete="off"
+              />
+            </div>
+            <div class="col-12 col-md-4 text-md-end">
+              <p class="small text-white-50 mb-0">
+                Showing {{ visibleCount }} of {{ totalGames }} games
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="hasResults" class="row gy-5">
+          <div
+            v-for="category in filteredCategories"
+            :key="category.id"
+            class="col-12 col-lg-6"
+          >
+            <div class="content-card text-white h-100">
+              <h2 class="h4 text-uppercase text-white-50 mb-3">{{ category.title }}</h2>
+              <p class="small text-white-50 mb-4" v-if="category.description">{{ category.description }}</p>
+              <div class="row row-cols-1 row-cols-sm-2 g-3">
+                <div v-for="game in category.games" :key="game.name" class="col">
+                  <a class="btn btn-outline-white w-100" :href="game.url">
+                    {{ game.name }}
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="content-card text-white text-center py-5">
+          <p class="lead mb-3">No games match that search just yet.</p>
+          <button class="btn btn-outline-white btn-lg" type="button" @click="clearSearch">
+            Clear search
+          </button>
+        </div>
+      </div>
+    `
+  }).mount(mountPoint);
+};
+
+mountGameApp('#game-app');

--- a/js/proxyApp.js
+++ b/js/proxyApp.js
@@ -1,0 +1,163 @@
+import { computed, createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js';
+
+const proxyConfigurations = [
+  {
+    name: 'Page Request',
+    url: 'selection4.html',
+    description: 'Submit a site or game request for review by the GoldenNetwork staff team.',
+    type: 'Support',
+    tags: ['request', 'form']
+  },
+  {
+    name: 'Local Proxy V2',
+    url: 'mini.php',
+    description: 'Modern local proxy with TLS support and the fastest response times for most sites.',
+    type: 'Local Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['local', 'proxy', 'tls']
+  },
+  {
+    name: 'CensorDodge',
+    url: 'local.html',
+    description: 'Classic PHP proxy that emphasises compatibility with legacy school filtering systems.',
+    type: 'Local Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['local', 'php', 'legacy']
+  },
+  {
+    name: 'Local PHP-Proxy',
+    url: 'local-2.html',
+    description: 'Alternative PHP-based proxy that balances performance with stability.',
+    type: 'Local Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['local', 'php']
+  },
+  {
+    name: 'Local YouTube Proxy',
+    url: 'youtube.html',
+    description: 'Optimised proxy specifically tuned for YouTube playback and media streaming.',
+    type: 'Media Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['youtube', 'media', 'video']
+  },
+  {
+    name: 'External Server #1: Muun',
+    url: 'externalserver1.html',
+    description: 'Externally hosted Muun proxy instance offering resilient access during local outages.',
+    type: 'External Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['external', 'muun']
+  },
+  {
+    name: 'External Server #2: Node Unblocker',
+    url: 'externalserver2.html',
+    description: 'Node Unblocker deployment that delivers a wide range of site compatibility.',
+    type: 'External Proxy',
+    status: { text: 'Running', variant: 'success' },
+    tags: ['external', 'node', 'proxy']
+  }
+];
+
+const normalise = (value) => value.toLowerCase();
+
+const mountProxyApp = (mountSelector) => {
+  const mountPoint = document.querySelector(mountSelector);
+  if (!mountPoint) {
+    return;
+  }
+
+  const totalCount = proxyConfigurations.length;
+
+  createApp({
+    setup() {
+      const searchTerm = ref('');
+
+      const filteredProxies = computed(() => {
+        const query = normalise(searchTerm.value.trim());
+        if (!query) {
+          return proxyConfigurations;
+        }
+
+        return proxyConfigurations.filter((proxy) => {
+          const haystack = [proxy.name, proxy.type, proxy.description, ...(proxy.tags ?? [])]
+            .filter(Boolean)
+            .map((entry) => normalise(entry));
+
+          return haystack.some((entry) => entry.includes(query));
+        });
+      });
+
+      const visibleCount = computed(() => filteredProxies.value.length);
+      const hasResults = computed(() => visibleCount.value > 0);
+
+      const getStatusClass = (variant) => {
+        if (variant === 'success') {
+          return 'badge-soft-success';
+        }
+        return 'badge-soft-success';
+      };
+
+      const clearSearch = () => {
+        searchTerm.value = '';
+      };
+
+      return {
+        clearSearch,
+        filteredProxies,
+        getStatusClass,
+        hasResults,
+        searchTerm,
+        totalCount,
+        visibleCount
+      };
+    },
+    template: /* html */ `
+      <div class="content-card text-white h-100 d-flex flex-column gap-4">
+        <div>
+          <label class="form-label text-white-50 fw-semibold" for="proxy-search">Search proxy options</label>
+          <input
+            id="proxy-search"
+            class="form-control form-control-lg"
+            type="search"
+            placeholder="Filter by name, type, or capability"
+            v-model.trim="searchTerm"
+            autocomplete="off"
+          />
+          <p class="small text-white-50 mb-0 mt-2">
+            Showing {{ visibleCount }} of {{ totalCount }} options
+          </p>
+        </div>
+
+        <div v-if="hasResults" class="hero-button-group">
+          <a
+            v-for="proxy in filteredProxies"
+            :key="proxy.name"
+            class="btn btn-outline-white btn-lg btn-status text-start"
+            :href="proxy.url"
+          >
+            <span class="flex-grow-1">
+              <span class="d-block fw-semibold">{{ proxy.name }}</span>
+              <span class="d-block small text-white-50">{{ proxy.description }}</span>
+            </span>
+            <span
+              v-if="proxy.status"
+              class="ms-3"
+              :class="getStatusClass(proxy.status.variant)"
+            >
+              {{ proxy.status.text }}
+            </span>
+          </a>
+        </div>
+
+        <div v-else class="text-center py-5">
+          <p class="lead mb-3">No proxies match that search just yet.</p>
+          <button class="btn btn-outline-white btn-lg" type="button" @click="clearSearch">
+            Clear search
+          </button>
+        </div>
+      </div>
+    `
+  }).mount(mountPoint);
+};
+
+mountProxyApp('#proxy-app');

--- a/js/year.js
+++ b/js/year.js
@@ -1,0 +1,12 @@
+const setCurrentYear = () => {
+  const yearElement = document.getElementById('currentYear');
+  if (yearElement) {
+    yearElement.textContent = new Date().getFullYear().toString();
+  }
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setCurrentYear);
+} else {
+  setCurrentYear();
+}

--- a/selection.html
+++ b/selection.html
@@ -41,35 +41,7 @@
               <p class="lead mb-0"><a class="link-light fw-semibold" href="public-txt/tos.txt">View the Terms of Service</a> you agree to by using GoldenNetwork.</p>
             </div>
             <div class="col-12 col-lg-6">
-              <div class="hero-button-group">
-                <a class="btn btn-outline-white btn-lg btn-status" href="selection4.html">
-                  Page Request
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="mini.php">
-                  Local Proxy V2
-                  <span class="badge-soft-success">Running</span>
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="local.html">
-                  CensorDodge
-                  <span class="badge-soft-success">Running</span>
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="local-2.html">
-                  Local PHP-Proxy
-                  <span class="badge-soft-success">Running</span>
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="youtube.html">
-                  Local YouTube Proxy
-                  <span class="badge-soft-success">Running</span>
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="externalserver1.html">
-                  External Server #1: Muun
-                  <span class="badge-soft-success">Running</span>
-                </a>
-                <a class="btn btn-outline-white btn-lg btn-status" href="externalserver2.html">
-                  External Server #2: Node Unblocker
-                  <span class="badge-soft-success">Running</span>
-                </a>
-              </div>
+              <div id="proxy-app"></div>
             </div>
           </div>
         </div>
@@ -80,9 +52,8 @@
       <div class="container small">&copy; <span id="currentYear"></span> GoldenNetwork. All rights reserved.</div>
     </footer>
 
-    <script>
-      document.getElementById('currentYear').textContent = new Date().getFullYear();
-    </script>
+    <script type="module" src="js/year.js"></script>
+    <script type="module" src="js/proxyApp.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-3gJwYpZj0hISBkV2YIfJfnLyC3xaQa58ae0q/QAdzTZziEtGlUZt6I4v9ZR6N9F2" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="js/site.js"></script>

--- a/selection3.html
+++ b/selection3.html
@@ -50,121 +50,7 @@
 
       <section class="py-5">
         <div class="container">
-          <div class="row gy-5">
-            <div class="col-12 col-lg-6">
-              <div class="content-card text-white h-100">
-                <h2 class="h4 text-uppercase text-white-50 mb-3">HTML5 Games</h2>
-                <div class="row row-cols-1 row-cols-sm-2 g-3">
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/2048/index.html">2048</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/astray/index.html">Astray</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/breaklock/index.html">Breaklock</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/nerd.html">Breakout</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/cookies/index.html">Cookie Clicker</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/flappybird/index.html">Flappy Bird</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/hextris/index.html">Hextris</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/onslaughtarena.html">Onslaught! Arena</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/pacman/index.htm">Pac-Man</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/radius-raid/min.html">Radius Raid</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/spaceinvaders/index.html">Space Invaders</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/html5games/towermaster/index.html">Towermaster</a></div>                </div>
-              </div>
-            </div>
-            <div class="col-12 col-lg-6">
-              <div class="content-card text-white h-100">
-                <h2 class="h4 text-uppercase text-white-50 mb-3">Flash Games</h2>
-                <div class="row row-cols-1 row-cols-sm-2 g-3">
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/1-on-1-soccer.html">1 on 1 soccer</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/achievement-unlocked.html">Achievement Unlocked</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/achievementunlocked2.html">Achievement Unlocked 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/achievementunlocked3.html">Achievement Unlocked 3</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/action-turnip.html">Action Turnip</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/adaran.html">Adaran</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/adrenaline.html">Adrenaline</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/agario.html">Agar.io</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/arkandianrenevant.html">Arkandian Renevant</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/awesome-cars.html">Awesome Cars</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/awesome-planes.html">Awesome Planes</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/balloons-player-pack-2.html">Bloons Player Pack 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/bloonstd3.html">Bloons TD 3</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/bloonstd4.html">Bloons TD 4</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/balloons-td-5.html">Bloons TD 5</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/boombot2.html">BoomBot 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/boxhead2player.html">Boxhead 2 player</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/bulletbill.html">Bullet Bill</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/casualty.html">Casualty Chrome</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/computerbreak.html">Computer Smashing</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/crushthecastle.html">Crush The Castle</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/cubefield.html">Cubefield</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/cyclomaniacs.html">Cyclomaniacs</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/donkeykong.html">Donkey Kong</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/dontshootthepuppy.html">Don't Shoot The Puppy</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/doodledefender.html">Doodle Defender</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/doom.html">Doom</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/ducklife4.html">Duck Life 4</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/earntodiesw.html">Earn To Die : Super Wheel</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/electricman.html">Electric Man</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/electricman2.html">Electric Man 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/elephantquest.html">Elephant Quest</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/epiccomboredux.html">Epic Combo : Redux</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/exitpath.html">Exit Path</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/fancypantsworld3.html">Fancy Pants World 3</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/flashflightsimulator.html">Flash Flight Simulator</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/flight.html">Flight</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/happywheels.html">Happy Wheels</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo.html">Hobo</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo2.html">Hobo : Prison Brawl</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo3.html">Hobo 3</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo5.html">Hobo 5</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo5.html">Hobo 5</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/hobo6.html">Hobo 6</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/infector2.html">Infector 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/interactivebuddy.html">Interactive Buddy</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/jumpix2.html">Jumpix 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/learntofly.html">Learn To Fly</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/learntofly2.html">Learn To Fly 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/magnetface.html">Magnet Face</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/marioracingtournament.html">Mario Racing Tournament</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/megamanprojectx.html">Megaman Project X</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/metroid2.html">Metroid 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/mineblocks.html">Mineblocks</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/millionairetobillionaire.html">Millionaire to Billionaire</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/mirrorsedge.html">Mirror's Edge</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/motherload.html">Motherload</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/multitask.html">Multitask</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/mutilateadoll.html">Mutilate A Doll 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/myangel.html">My Angel</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/nanotube.html">Nanotube</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/ngame.html">N Game</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/ngame2.html">N Game 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/nucleus.html">Nucleus</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/nyancat.html">Nyan Cat : lost in space</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/onemanarmy2.html">One man army 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/pandemic.html">Pandemic</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/pandemic2.html">Pandemic 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/papasfreezeria.html">Papas Freezeria</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/pauseahead.html">Pause Ahead</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/portal.html">Portal</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/portal2d.html">Portal 2D</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/raftwars.html">Raftwars</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/raze2.html">Raze 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/redshift.html">Redshift</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/run3.html">Run 3</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/smashflash2.html">Super Smash Flash 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/sportsheadssoccer.html">Sports Heads Soccer</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/stickrpg.html">Stick RPG</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/stickrun2.html">Stick Run 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/stickwar.html">Stick War</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/stickwar2.html">Stick War 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/strikeforceheroes.html">Strike Force Heroes</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/strikeforceheroes2.html">Strike Force Heroes 2</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/strikeforcekittyls.html">Strike Force Kitty : Last Stand</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/supermario63.html">Super Mario 63</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/tacticalassassin.html">Tactical Assassin</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/tanktrouble.html">Tank Trouble</a></div>
-                  <div class="col"><a class="btn btn-outline-white w-100" href="gfiles/thebindingofisaac.html">The Binding Of Isaac</a></div>                </div>
-              </div>
-            </div>
-          </div>
+          <div id="game-app"></div>
         </div>
       </section>
     </main>
@@ -173,9 +59,8 @@
       <div class="container small">&copy; <span id="currentYear"></span> GoldenNetwork. All rights reserved.</div>
     </footer>
 
-    <script>
-      document.getElementById('currentYear').textContent = new Date().getFullYear();
-    </script>
+    <script type="module" src="js/year.js"></script>
+    <script type="module" src="js/gameApp.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-3gJwYpZj0hISBkV2YIfJfnLyC3xaQa58ae0q/QAdzTZziEtGlUZt6I4v9ZR6N9F2" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="js/site.js"></script>


### PR DESCRIPTION
## Summary
- replace the static proxy selection markup with a Vue-powered, searchable interface
- rebuild the games library page as a Vue app with filtering and dynamic counts
- extract the footer year update into a shared ES module for reuse across pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df65cf62248323a58db6324c1a1b6d