### PR TITLE
Refine selection layout with centered card

### DIFF
--- a/css/primary.css
+++ b/css/primary.css
@@ -87,29 +87,30 @@ footer {
 
 .hero-section {
   position: relative;
-  padding: 7rem 0 4rem;
+  padding: var(--hero-section-padding-y, 7rem) 0 4rem;
 }
 
 @media (min-width: 768px) {
   .hero-section {
-    padding: 8.5rem 0 6rem;
+    padding: var(--hero-section-padding-y-lg, 8.5rem) 0 6rem;
   }
 }
 
-.hero-section .section-heading {
+.section-heading {
   font-size: clamp(2.5rem, 5vw, 3.5rem);
   font-weight: 700;
   text-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.45);
 }
 
-.hero-section .section-subheading {
+.section-subheading {
   font-size: clamp(1.25rem, 3vw, 2rem);
   font-weight: 600;
   margin-bottom: 1.5rem;
   text-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.35);
 }
 
-.hero-section .lead {
+.hero-section .lead,
+.hero-lead {
   font-weight: 400;
   line-height: 1.7;
   max-width: 46rem;

--- a/selection.html
+++ b/selection.html
@@ -30,18 +30,20 @@
     </nav>
 
     <main>
-      <section class="hero-section d-flex align-items-center">
+      <section class="py-5 py-lg-6">
         <div class="container">
-          <div class="row align-items-center gy-5">
-            <div class="col-12 col-lg-6">
+          <div class="row justify-content-center align-items-center g-5">
+            <div class="col-12 col-lg-10 col-xl-5">
               <h1 class="section-heading">GoldenNetwork</h1>
               <h2 class="section-subheading">Select a server.</h2>
-              <p class="lead">This website is secured with 128-bit SSL and TLS 1.0 through TLS 1.2. If you do not see a security indicator in your address bar, we recommend using a newer site for your own privacy.</p>
-              <p class="lead">All local proxies inherit the same protection as the site you're currently on. We cannot fully guarantee the security of any external servers, though they were safe at the time of being added. If you find any vulnerabilities, contact staff immediately.</p>
-              <p class="lead mb-0"><a class="link-light fw-semibold" href="public-txt/tos.txt">View the Terms of Service</a> you agree to by using GoldenNetwork.</p>
+              <p class="lead hero-lead">This website is secured with 128-bit SSL and TLS 1.0 through TLS 1.2. If you do not see a security indicator in your address bar, we recommend using a newer site for your own privacy.</p>
+              <p class="lead hero-lead">All local proxies inherit the same protection as the site you're currently on. We cannot fully guarantee the security of any external servers, though they were safe at the time of being added. If you find any vulnerabilities, contact staff immediately.</p>
+              <p class="lead hero-lead mb-0"><a class="link-light fw-semibold" href="public-txt/tos.txt">View the Terms of Service</a> you agree to by using GoldenNetwork.</p>
             </div>
-            <div class="col-12 col-lg-6">
-              <div id="proxy-app"></div>
+            <div class="col-12 col-lg-10 col-xl-5">
+              <div class="card bg-dark bg-opacity-50 border-light rounded-4 shadow-lg p-4">
+                <div id="proxy-app"></div>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the selection hero section with a centered responsive layout that uses Bootstrap spacing utilities
- wrap the proxy mount point in a dark glass card so it aligns with the new grid
- refactor hero text styles to work without the hero-section wrapper and expose padding variables for other pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dffb7e25348323b92c76fd53ebfdab