### PR TITLE
Add shared layout templates and streamline primary stylesheet

### DIFF
--- a/css/primary.css
+++ b/css/primary.css
@@ -1,3 +1,6 @@
+/* ========================================
+   Global Styles
+   ======================================== */
 :root {
   --gn-navbar-bg: rgba(49, 15, 34, 0.7);
   --gn-navbar-bg-scrolled: rgba(122, 124, 128, 0.95);
@@ -23,7 +26,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: url('http://hdqwalls.com/wallpapers/firewatch-forest-mountains-minimalism-4k-hb.jpg') center center / cover fixed no-repeat;
+  background: url("http://hdqwalls.com/wallpapers/firewatch-forest-mountains-minimalism-4k-hb.jpg") center center / cover fixed no-repeat;
 }
 
 body::before {
@@ -36,29 +39,38 @@ body::before {
 
 main {
   flex: 1 0 auto;
+  padding-top: 6rem;
 }
 
 footer {
   flex-shrink: 0;
 }
 
-.whitebg::before {
+body.whitebg::before {
   background: none !important;
 }
 
-.whitebg {
+body.whitebg {
   background: #fff !important;
   color: #212529;
 }
 
-.whitebg .navbar {
+body.whitebg .navbar {
   background-color: rgba(33, 37, 41, 0.92);
 }
 
-.nobg {
+body.nobg {
   background-color: #fff;
 }
 
+.footer.footer {
+  background: rgba(0, 0, 0, 0.35);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* ========================================
+   Navbar Styles
+   ======================================== */
 .navbar {
   background: transparent;
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
@@ -70,11 +82,8 @@ footer {
   letter-spacing: 0.05em;
 }
 
-.navbar .btn {
-  font-weight: 600;
-}
-
-.navbar-scrolled {
+.navbar-scrolled,
+.navbar.navbar-scrolled {
   background-color: var(--gn-navbar-bg-scrolled) !important;
   box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.35);
 }
@@ -85,6 +94,9 @@ footer {
   letter-spacing: 0.04em;
 }
 
+/* ========================================
+   Hero Sections
+   ======================================== */
 .hero-section {
   position: relative;
   padding: var(--hero-section-padding-y, 7rem) 0 4rem;
@@ -116,6 +128,22 @@ footer {
   max-width: 46rem;
 }
 
+.hero-button-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  .hero-button-group {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+/* ========================================
+   Button Variants
+   ======================================== */
 .btn-soft-dark {
   background-color: rgba(0, 0, 0, 0.35);
   color: #fff;
@@ -159,6 +187,9 @@ footer {
   border-color: rgba(255, 255, 255, 0.35);
 }
 
+/* ========================================
+   Card Components
+   ======================================== */
 .card-glass {
   background-color: rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -185,6 +216,33 @@ footer {
   padding-left: 1.25rem;
 }
 
+.content-card li + li {
+  margin-top: 0.5rem;
+}
+
+.c-box,
+.d-box {
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(6px);
+}
+
+.c-box {
+  background: rgba(14, 18, 36, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #f8f9fa;
+}
+
+.d-box {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  color: #212529;
+}
+
+/* ========================================
+   Utilities & Components
+   ======================================== */
 .proxy-btn .small {
   color: rgba(255, 255, 255, 0.65);
 }
@@ -193,10 +251,6 @@ footer {
   font-size: 0.75rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.content-card li + li {
-  margin-top: 0.5rem;
 }
 
 .embed-frame {
@@ -217,12 +271,9 @@ footer {
   text-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.45);
 }
 
-footer.footer {
-  background: rgba(0, 0, 0, 0.35);
-  color: rgba(255, 255, 255, 0.75);
-}
-
-/* Legacy Discord widget styles retained for backwards compatibility */
+/* ========================================
+   Discord Dialog
+   ======================================== */
 .discord-dialog *,
 .discord-dialog *:before,
 .discord-dialog *:after {

--- a/templates/template_footer.php
+++ b/templates/template_footer.php
@@ -1,0 +1,16 @@
+      </div>
+    </main>
+
+    <footer class="footer text-center py-4">
+      <div class="container small">&copy; <?= date('Y'); ?> GoldenNetwork. All rights reserved.</div>
+    </footer>
+
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
+    <script src="/js/site.js"></script>
+    <script src="/js/main.js"></script>
+  </body>
+</html>

--- a/templates/template_header.php
+++ b/templates/template_header.php
@@ -1,0 +1,59 @@
+<?php
+$pageTitle = $pageTitle ?? 'GoldenNetwork';
+$bodyClass = $bodyClass ?? '';
+?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title><?= htmlspecialchars($pageTitle, ENT_QUOTES, 'UTF-8'); ?></title>
+    <link rel="icon" href="https://ssl.gstatic.com/docs/doclist/images/infinite_arrow_favicon_5.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link href="/css/primary.css" rel="stylesheet" />
+  </head>
+  <body class="<?= htmlspecialchars($bodyClass, ENT_QUOTES, 'UTF-8'); ?>">
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top py-3" id="mainNav">
+      <div class="container">
+        <a class="navbar-brand" href="/index.html"><strong>GoldenNetwork</strong></a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarContent"
+          aria-controls="navbarContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarContent">
+          <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="/selection3.html">Games</a></li>
+            <li class="nav-item"><a class="nav-link" href="/contributors.html">Staff &amp; Contributors</a></li>
+          </ul>
+          <a
+            class="btn btn-primary ms-lg-3 mt-3 mt-lg-0"
+            href="https://github.com/titaniumnetwork-dev"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Check us out on GitHub!
+          </a>
+        </div>
+      </div>
+    </nav>
+
+    <main class="flex-grow-1 pt-5">
+      <div class="container py-5">


### PR DESCRIPTION
## Summary
- add reusable PHP header and footer templates that provide the shared navigation, footer, and script includes
- refactor `primary.css` into documented sections while consolidating global, hero, and card styling for reuse across pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e001ac29d883238bb962a2ba9b6ab8